### PR TITLE
Fix exported projects not running due to parse errors

### DIFF
--- a/addons/multi_spliter_container/helpers.gd
+++ b/addons/multi_spliter_container/helpers.gd
@@ -1,0 +1,6 @@
+extends Object
+
+class_name Helpers
+
+static func get_editor_interface():
+	return Engine.get_singleton("EditorInterface")

--- a/addons/multi_spliter_container/helpers.gd.uid
+++ b/addons/multi_spliter_container/helpers.gd.uid
@@ -1,0 +1,1 @@
+uid://bbqgku75a55dq

--- a/addons/multi_spliter_container/multi_split_container.gd
+++ b/addons/multi_spliter_container/multi_split_container.gd
@@ -41,7 +41,7 @@ const SplitButton : Texture = preload("res://addons/multi_spliter_container/icon
 	set(e):
 		separator_line_color = e
 		if separator_line_color == Color.MAGENTA: # That color reminds me of texture not found errors.
-			var root : Control = EditorInterface.get_base_control()
+			var root : Control = Helpers.get_editor_interface().get_base_control()
 			separator_line_color = root.get_theme_color("base_color", "Editor")
 		update()
 
@@ -123,7 +123,7 @@ const SplitButton : Texture = preload("res://addons/multi_spliter_container/icon
 		drag_button_modulate = e
 		if drag_button_modulate == Color.MAGENTA:
 			if Engine.is_editor_hint():
-				var root : Control = EditorInterface.get_base_control()
+				var root : Control = Helpers.get_editor_interface().get_base_control()
 				drag_button_modulate = root.get_theme_color("base_color", "Editor").lightened(0.5)
 		update()
 
@@ -688,7 +688,7 @@ func _undoredo_do(ur : UndoredoSplit) -> void:
 			if owner:
 				_recuva(container, owner)
 			else:
-				_recuva(container, EditorInterface.get_edited_scene_root())
+				_recuva(container, Helpers.get_editor_interface().get_edited_scene_root())
 		ur.object = container
 
 func _recuva(x : Node, _owner : Node) -> void:
@@ -745,7 +745,7 @@ func _update() -> void:
 					add_child(container, true)
 
 					if Engine.is_editor_hint():
-						var undoredo : EditorUndoRedoManager = EditorInterface.get_editor_undo_redo()
+						var undoredo = Helpers.get_editor_interface().get_editor_undo_redo()
 
 						var id : int = undoredo.get_object_history_id(x)
 						var _undoredo : UndoRedo = undoredo.get_history_undo_redo(id)
@@ -772,7 +772,7 @@ func _update() -> void:
 						if owner:
 							_recuva(container, owner)
 						else:
-							_recuva(container, EditorInterface.get_edited_scene_root())
+							_recuva(container, Helpers.get_editor_interface().get_edited_scene_root())
 
 					x.reparent(container)
 					x = container

--- a/addons/multi_spliter_container/split_container_item.gd
+++ b/addons/multi_spliter_container/split_container_item.gd
@@ -44,7 +44,7 @@ func _on_child_entered_tree(n : Node) -> void:
 				n.gui_input.connect(_on_gui_input)
 	else:
 		if n.owner == null:
-			n.owner = EditorInterface.get_edited_scene_root()
+			n.owner = Helpers.get_editor_interface().get_edited_scene_root()
 	for x : Node in n.get_children():
 		_on_child_entered_tree(x)
 
@@ -69,7 +69,7 @@ func _enter_tree() -> void:
 			if get_parent().owner:
 				owner = get_parent().owner
 			else:
-				owner = EditorInterface.get_edited_scene_root()
+				owner = Helpers.get_editor_interface().get_edited_scene_root()
 		if get_child_count() > 0:
 			if is_queued_for_deletion():
 				cancel_free()


### PR DESCRIPTION
It's interesting that this seemingly hasn't come up yet.

This addon suffers from https://github.com/godotengine/godot/issues/91713 and this PR uses the fix proposed in https://forum.godotengine.org/t/how-to-strip-editor-specific-code-from-build-in-godot-4-2/41978

I use C# exclusively so I'm not at all familiar how to write idiomatic gdscript, so feel free to change my code around as you see fit, the necessary change is not referring to any tool-exclusive classes statically.